### PR TITLE
Story - Related data paging

### DIFF
--- a/related-data-paging.sql
+++ b/related-data-paging.sql
@@ -1,0 +1,135 @@
+------------------------------------------------
+-- This is a SQL "notepad" that demonstrates examples of each combination
+-- of many-to-many or not and range-constrained or not.
+------------------------------------------------
+
+select * from "user"
+
+select * from "user_group"
+
+select * from user_to_user_group
+
+select * from "image"
+
+select * from "image" where creator_user_id = 2
+
+------------------------------------------------
+-- non-many-to-many, non-range-constrained
+------------------------------------------------
+select
+-- Root data node columns
+"1".uuid "1.uuid", "1".date_created "1.dateCreated", "1".file_name "1.fileName",
+-- Root data node linked field column
+"1".creator_user_id "1.creatorUserId",
+-- To-one related data columns
+"2".id "2.id", "2".name "2.name"
+-- Root from
+from "image" "1"
+-- To-one related data left joins
+left join "user" "2" on "2".id = "1"."creator_user_id"
+-- Linked field value where clause
+where "1".creator_user_id = any (values (1),(2),(3))
+-- 	Root data node query SQL
+and "1".date_deleted is null
+order by "1".id
+
+------------------------------------------------
+-- non-many-to-many, range-constrained
+------------------------------------------------
+select
+-- Root data node columns
+"1"."uuid" "1.uuid", "1"."file_name" "1.fileName",
+-- Root data node linked field column
+"1"."creator_user_id" "1.creatorUserId",
+-- To-one related data columns
+"2".id "2.id", "2".name "2.name"
+-- Root from
+from "user" "_0"
+-- Range-constraint part of root "from"
+left join lateral (
+	select
+	"uuid", "date_created", "file_name", "creator_user_id"
+	from "image" "1"
+	where "1".creator_user_id = "_0"."id"
+	-- 	Root data node query SQL
+	and "1"."date_deleted" is null
+	order by "1".id
+	limit 2
+	offset 2
+) as "1" on "1"."creator_user_id" = "_0"."id"
+-- To-one related data left joins
+left join "user" "2" on "2".id = "1"."creator_user_id"
+-- Linked field value where clause
+where "1"."creator_user_id" = any (values (1),(2),(3))
+
+------------------------------------------------
+-- many-to-many, non-range-constrained
+------------------------------------------------
+select
+-- Root data node columns
+"1".id "1.id", "1".uuid "1.uuid", "1".name "1.name", "1".date_created "1.dateCreated",
+-- Root data node join table columns
+"u2ug".user_id "u2ug.user_id", "u2ug".user_group_id "u2ug.user_group_id",
+-- To-one related data columns
+"2".id "2.id", "2".name "2.name"
+-- Root from
+from "user_to_user_group" "u2ug"
+join "user_group" "1" on "1".id = "u2ug".user_group_id
+-- To-one related data left joins
+left join "user" "2" on "2".id = "1"."id"
+-- Linked field value where clause
+where "u2ug".user_id = any (values (1),(2),(3))
+-- 	Root data node query SQL
+and "1".date_deleted is null
+order by "1".id
+
+------------------------------------------------
+-- many-to-many, range-constrained
+------------------------------------------------
+select
+-- Root data node columns
+"1"."id" "1.id", "1"."uuid" "1.uuid", "1"."name" "1.name", "1"."date_created" "1.dateCreated",
+-- Root data node join table columns
+"1"."u2ug.user_id" "u2ug.user_id", "1"."u2ug.user_group_id" "u2ug.user_group_id",
+-- To-one related data columns
+"2".id "2.id", "2".name "2.name"
+-- Root from
+from "user" "_0"
+-- Range-constraint part of root "from"
+join lateral (
+	select
+	"1".id "id", "1".uuid "uuid", "1".name "name", "1".date_created "date_created",
+	"u2ug".user_id "u2ug.user_id", "u2ug".user_group_id "u2ug.user_group_id"
+	from "user_to_user_group" "u2ug"
+	join "user_group" "1" on "1".id = "u2ug"."user_group_id"
+	where "u2ug"."user_id" = "_0"."id"
+	-- Root data node query SQL
+	and "1".date_deleted is null
+	order by "1".id
+	limit 2
+	offset 2
+) as "1" on "1"."u2ug.user_id" = "_0"."id"
+-- To-one related data left joins
+left join "user" "2" on "2".id = "1"."id"
+-- Linked field value where clause
+where "_0"."id" = any (values (1),(2),(3))
+
+
+select
+"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".creator_user_id "0.creatorUserId",
+"1".id "1.id", "1".name "1.name",
+"2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
+from "article" "0"
+left join "user" "1" on "1".id = "0".creator_user_id
+left join "user_address" "2" on "2".user_id = "1".id
+where "0".date_deleted is null
+limit 1
+
+select * from article
+
+select
+"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title",
+"4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
+from "recipe" "3"
+left join "image" "4" on "4".id = "3".image_id
+where "3".created_by_user_id = any (values (1),(2),(3))

--- a/related-data-paging.sql
+++ b/related-data-paging.sql
@@ -1,8 +1,3 @@
-------------------------------------------------
--- This is a SQL "notepad" that demonstrates examples of each combination
--- of many-to-many or not and range-constrained or not.
-------------------------------------------------
-
 select * from "user"
 
 select * from "user_group"
@@ -37,6 +32,7 @@ order by "1".id
 -- non-many-to-many, range-constrained
 ------------------------------------------------
 select
+"_0".id "_0.id", "_0".name "_0.name",
 -- Root data node columns
 "1"."uuid" "1.uuid", "1"."file_name" "1.fileName",
 -- Root data node linked field column
@@ -46,7 +42,7 @@ select
 -- Root from
 from "user" "_0"
 -- Range-constraint part of root "from"
-left join lateral (
+join lateral (
 	select
 	"uuid", "date_created", "file_name", "creator_user_id"
 	from "image" "1"
@@ -60,7 +56,7 @@ left join lateral (
 -- To-one related data left joins
 left join "user" "2" on "2".id = "1"."creator_user_id"
 -- Linked field value where clause
-where "1"."creator_user_id" = any (values (1),(2),(3))
+where "_0"."id" = any (values (1),(2),(3))
 
 ------------------------------------------------
 -- many-to-many, non-range-constrained
@@ -116,20 +112,16 @@ where "_0"."id" = any (values (1),(2),(3))
 
 
 select
-"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".creator_user_id "0.creatorUserId",
-"1".id "1.id", "1".name "1.name",
-"2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
-from "article" "0"
-left join "user" "1" on "1".id = "0".creator_user_id
-left join "user_address" "2" on "2".user_id = "1".id
-where "0".date_deleted is null
-limit 1
-
-select * from article
-
+"1".id "1.id", "1".uuid "1.uuid", "1".date_created "1.dateCreated", "1".date_deleted "1.dateDeleted", "1".name "1.name", "1".description "1.description", "1".image_id "1.imageId",
+"1"."user_to_user_group.user_id" "user_to_user_group.user_id", "1"."user_to_user_group.user_group_id" "user_to_user_group.user_group_id"
+from "user" "_0"
+join lateral (
 select
-"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title",
-"4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
-from "recipe" "3"
-left join "image" "4" on "4".id = "3".image_id
-where "3".created_by_user_id = any (values (1),(2),(3))
+"1"."id" "id", "1"."uuid" "uuid", "1"."date_created" "date_created", "1"."date_deleted" "date_deleted", "1"."name" "name", "1"."description" "description", "1"."image_id" "image_id",
+"user_to_user_group".user_id "user_to_user_group.user_id", "user_to_user_group".user_group_id "user_to_user_group.user_group_id"
+from user_to_user_group "user_to_user_group"
+join "user_group" "1" on "1".id = "user_to_user_group"."user_group_id"
+where "user_to_user_group"."user_id" = "_0"."id"
+limit 1 offset 0
+) as "1" on "1"."user_to_user_group.user_id" = "_0"."id"
+where "_0"."id" = any (values (1),(2),(3))

--- a/src/dataFormat/index.ts
+++ b/src/dataFormat/index.ts
@@ -131,9 +131,8 @@ export const createDataFormat = <T extends DataFormatDeclaration>(
         if (fname === COMMON_FIELDS.dateDeleted.name)
           return
 
-        // TODO: Although fname is always going to be a key in "fields", TS doesn't see it.
-        // @ts-ignore
-        record[fname] = createSampleData(fields[fname])
+        // Although fname is always going to be a key in "fields", TS doesn't see it.
+        (record as any)[fname] = createSampleData(fields[fname])
       })
       return record
     },

--- a/src/dataFormat/index.ts
+++ b/src/dataFormat/index.ts
@@ -114,7 +114,7 @@ export const createDataFormat = <T extends DataFormatDeclaration>(
     name: dataFormatDeclaration.name,
     capitalizedName: capitalize(dataFormatDeclaration.name) as any,
     pluralizedName,
-    capitalizedPluralizedName: capitalize(pluralizedName),
+    capitalizedPluralizedName: capitalize(pluralizedName) as any,
     declaration: dataFormatDeclaration,
     fields,
     fieldNames: fieldNamesDict,

--- a/src/dataFormat/types.ts
+++ b/src/dataFormat/types.ts
@@ -6,78 +6,78 @@ export enum DataType {
   /**
    * Any numeric value, i.e. integer, serial, real.
    */
-  NUMBER,
+  NUMBER = 'num',
   /**
    * Any string value, i.e. varying length, fixed length, etc.
    */
-  STRING,
+  STRING = 'str',
   /**
    * Any boolean value
    */
-  BOOLEAN,
+  BOOLEAN = 'bool',
   /**
    * Any epoch value, i.e. time, date, date-time, date-time with timezone.
    */
-  DATE,
+  DATE = 'date',
   /**
    * Any object or array value.
    */
-  JSON
+  JSON = 'json'
 }
 
 export enum NumberDataSubType {
-  INTEGER,
+  INTEGER = 'int',
   /**
    * A serial integer value. This is likely to be for the unique primary key field of the data format.
    */
-  SERIAL,
-  REAL
+  SERIAL = 'ser',
+  REAL = 'real'
 }
 
 export enum StringDataSubType {
   /**
    * A string value that is a UUID V4, i.e. a 36 character randomly-generated string.
    */
-  UUID_V4,
+  UUID_V4 = 'uuidv4',
   /**
    * A fixed-length string.
    */
-  FIXED_LENGTH,
+  FIXED_LENGTH = 'fixed',
   /**
    * A varying-length string.
    */
-  VARYING_LENGTH,
+  VARYING_LENGTH = 'var',
   /**
    * A string that, underlying, is some kind of enumeration.
    */
-  STRING_ENUM,
+  STRING_ENUM = 'enum',
 }
 
 export enum BooleanDataSubType {
-  TRUE_FALSE,
+  TRUE_FALSE = 'truefalse',
 }
 
 export enum DateDataSubType {
-  DATE,
-  TIME,
-  DATE_TIME,
-  DATE_TIME_WITH_TIMEZONE
+  DATE = 'date',
+  TIME = 'time',
+  DATE_TIME = 'datetime',
+  DATE_TIME_WITH_TIMEZONE = 'datetime_timezone'
 }
 
 export enum ThreeStepNumberSize {
-  SMALL,
-  REGULAR,
-  LARGE,
+  SMALL = 'small',
+  REGULAR = 'reg',
+  LARGE = 'large',
 }
 
 export enum TwoStepNumberSize {
-  REGULAR,
-  LARGE,
+  REGULAR = 'reg',
+  LARGE = 'large',
 }
 
 export enum JsonDataSubType {
-  ARRAY,
-  OBJECT
+  ARRAY = 'arr',
+  OBJECT = 'obj'
 }
 
 export type DataTypeToSubType = {

--- a/src/examples/realDbTest/index.ts
+++ b/src/examples/realDbTest/index.ts
@@ -247,6 +247,19 @@ const init = async () => {
   }), 'query')
   fs.writeFileSync(path.resolve(outputDir, 'user-user-groups-query.json'), JSON.stringify(result2.result, null, 2))
 
+  const result3 = await timedFn(() => stores.user.getMultiple({
+    fields: [],
+    relations: {
+      userGroups: {
+        query: {
+          page: 1,
+          pageSize: 1,
+        },
+      },
+    },
+  }), 'query')
+  fs.writeFileSync(path.resolve(outputDir, 'user-user-groups-query-range-constraint.json'), JSON.stringify(result3.result, null, 2))
+
   const dtList: number[] = []
   await repeatTimedFn(() => getResult(stores), 'query', 10, dtList)
   const avgDt = dtList.reduce((acc, dt) => acc + dt, 0) / dtList.length

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -9,3 +9,13 @@ export const removeDuplicates = <T>(array: T[]): T[] => {
     acc.indexOf(item) === -1 ? acc.concat(item) : acc
   ), [])
 }
+
+export const removeNullAndUndefinedValues = <T>(array: T[]): T[] => {
+  if (array == null)
+    return null
+
+  if (array.length === 0)
+    return []
+
+  return array.filter(item => item != null)
+}

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -53,14 +53,24 @@ export const capitalize = <T extends string>(s: T): Capitalize<T> => (
   `${s.charAt(0).toUpperCase()}${s.slice(1)}` as Capitalize<T>
 )
 
+/**
+ * Removes null, undefined, and empty strings from `arr`.
+ */
 export const filterForNotNullAndEmpty = (arr: string[]) => (
   arr.filter(s => s != null && s.length > 0)
 )
 
+/**
+ * Concatenates the list of strings - `arr`, if and only if `arr` is defined and has
+ * at least one entry.
+ */
 export const joinIfhasEntries = (arr: string[], joinStr: string) => (
   arr != null && arr.length > 0 ? arr.join(joinStr) : null
 )
 
+/**
+ * Concatenates `prefix` and `suffix` together if and only if both of them are defined.
+ */
 export const concatIfNotNullAndEmpty = (prefix: string, suffix: string) => {
   if (prefix != null && suffix != null)
     return prefix.concat(suffix)

--- a/src/relations/types.ts
+++ b/src/relations/types.ts
@@ -13,7 +13,7 @@ export enum RelationType {
    *
    * Foreign field: unique
    */
-  ONE_TO_ONE,
+  ONE_TO_ONE = 'one_to_one',
   /**
    * One item of this format relates to multiple items on another format.
    *
@@ -25,7 +25,7 @@ export enum RelationType {
    *
    * Foreign field: not unique
    */
-  ONE_TO_MANY,
+  ONE_TO_MANY = 'one_to_many',
   /**
    * Multiple items of this format relates to multiple items of another format.
    *
@@ -37,7 +37,7 @@ export enum RelationType {
    * Use `createJoinTables` to create them once the relations have been loaded into
    * the TsPgOrm instance.
    */
-  MANY_TO_MANY,
+  MANY_TO_MANY = 'many_to_many',
 }
 
 type ExtractAvailableFieldRefs<T extends DataFormatDeclarations> = ExpandRecursively<ValuesUnionFromDict<{

--- a/src/store/get/dataNodes.ts
+++ b/src/store/get/dataNodes.ts
@@ -3,7 +3,7 @@ import { removeDuplicates } from '../../helpers/array'
 import { toDict } from '../../helpers/dict'
 import { RelationsDict, RelationType, Relation, RelationDeclarations } from '../../relations/types'
 import { AnyGetFunctionOptions, GetFunctionOptions } from '../types/get'
-import { RelatedDataInfoDict, DataNodes, UnresolvedDataNodes, FieldsInfo, DataNode } from './types'
+import { RelatedDataInfoDict, DataNodes, UnresolvedDataNodes, FieldsInfo, DataNode, PluralDataNode, NonPluralDataNode } from './types'
 
 /**
  * Determines all of the related data properties of the given `dataFormat`
@@ -176,12 +176,12 @@ const createFieldsInfo = (dataNode: DataNode): FieldsInfo => {
     const parentJoinTableColumnName = isFieldRefFieldRef1
       ? dataNode.relation.sql.joinTableFieldRef2ColumnName
       : dataNode.relation.sql.joinTableFieldRef1ColumnName
-    joinTableParentFullyQualifiedColumnName = `"${joinTableAlias}".${parentJoinTableColumnName}`
+    joinTableParentFullyQualifiedColumnName = `"${joinTableAlias}"."${parentJoinTableColumnName}"`
     joinTableParentColumnNameAlias = `${joinTableAlias}.${parentJoinTableColumnName}`
     const joinTableColumnName = isFieldRefFieldRef1
       ? dataNode.relation.sql.joinTableFieldRef1ColumnName
       : dataNode.relation.sql.joinTableFieldRef2ColumnName
-    joinTableFullyQualifiedColumnName = `"${joinTableAlias}".${joinTableColumnName}`
+    joinTableFullyQualifiedColumnName = `"${joinTableAlias}"."${joinTableColumnName}"`
   }
 
   return {
@@ -211,6 +211,7 @@ const resolveDataNodes = (unresolvedDataNodes: UnresolvedDataNodes): DataNodes =
       relatedDataPropName: node.relatedDataPropName,
       relation: node.relation,
       tableAlias: `"${node.id}"`,
+      unquotedTableAlias: node.id.toString(),
       createColumnsSqlSegments: () => dataNode.fieldsInfo.fieldsToSelectFor.map(fName => (
         `${dataNode.fieldsInfo.fieldToFullyQualifiedColumnName[fName]} "${dataNode.fieldsInfo.fieldToColumnNameAlias[fName]}"`
       )),
@@ -260,8 +261,8 @@ export const toDataNodes = <
     unresolvedDataNodes,
     { id: 0 },
   )
-  /* Resolve each data node in the dict, which means, amongst some other changes, means
-   * to convert all of the child and parent data node id links into references to other
+  /* Resolve each data node in the dict, which means, amongst some other changes,
+   * converting all of the child and parent data node id links into references to other
    * data nodes. This will make things much easier later on in the query plan framework,
    * such as making it so that we don't have to carry around the whole data nodes dict
    * all the time (because each resovled data node will have direct references to
@@ -269,3 +270,5 @@ export const toDataNodes = <
    */
   return resolveDataNodes(unresolvedDataNodes)
 }
+
+export const isDataNodePlural = (dataNode: PluralDataNode | NonPluralDataNode): dataNode is PluralDataNode => dataNode.isPlural

--- a/src/store/get/queryNodeToSql.spec.ts
+++ b/src/store/get/queryNodeToSql.spec.ts
@@ -1,0 +1,150 @@
+import { Operator } from '@samhuk/data-filter/dist/types'
+import { tsPgOrm } from '../../testData'
+import { toDataNodes } from './dataNodes'
+import { toQueryNodes } from './queryNodes'
+import { toSqlNew } from './queryNodeToSql'
+
+describe('queryNodeToSql', () => {
+  describe('toSqlNew', () => {
+    const fn = toSqlNew
+
+    test('basic test - non-plural, no many-to-manys, no range constraints', () => {
+      const dataNodes = toDataNodes(
+        tsPgOrm.relations,
+        tsPgOrm.dataFormats,
+        tsPgOrm.dataFormats.article,
+        false,
+        {
+          fields: ['uuid', 'title', 'dateCreated', 'datePublished'],
+          filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+          relations: {
+            user: {
+              relations: {
+                userAddress: { },
+                recipes: {
+                  relations: {
+                    image: { },
+                  },
+                },
+              },
+            },
+          },
+        },
+      )
+
+      const queryNodes = toQueryNodes(dataNodes)
+
+      const queryNodeList = Object.values(queryNodes)
+
+      const result1 = fn(queryNodeList[0], [1, 2, 3])
+
+      expect(result1).toBe(`select
+"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished", "0".created_by_user_id "0.createdByUserId",
+"1".id "1.id", "1".name "1.name",
+"2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
+from "article" "0"
+left join "user" "1" on "1".id = "0".created_by_user_id
+left join "user_address" "2" on "2".user_id = "1".id
+where "0".date_deleted is null
+limit 1`)
+
+      const result2 = fn(queryNodeList[1], [1, 2, 3])
+
+      expect(result2).toBe(`select
+"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title",
+"4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
+from "recipe" "3"
+left join "image" "4" on "4".id = "3".image_id
+where "3".created_by_user_id = any (values (1),(2),(3))`)
+    })
+
+    test('basic test - non-plural, a many-to-many, range constraints', () => {
+      const dataNodes = toDataNodes(
+        tsPgOrm.relations,
+        tsPgOrm.dataFormats,
+        tsPgOrm.dataFormats.article,
+        false,
+        {
+          fields: ['uuid', 'title', 'dateCreated', 'datePublished'],
+          filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+          relations: {
+            user: {
+              relations: {
+                userAddress: { },
+                recipes: {
+                  query: {
+                    filter: { field: 'imageId', op: Operator.NOT_EQUALS, val: null },
+                    page: 1,
+                    pageSize: 2,
+                  },
+                  relations: {
+                    image: { },
+                  },
+                },
+                userGroups: {
+                  query: {
+                    page: 1,
+                    pageSize: 5,
+                  },
+                },
+              },
+            },
+          },
+        },
+      )
+
+      const queryNodes = toQueryNodes(dataNodes)
+
+      const queryNodeList = Object.values(queryNodes)
+
+      // The root node ()
+      const result1 = fn(queryNodeList[0], [])
+
+      expect(result1).toBe(`select
+"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished", "0".created_by_user_id "0.createdByUserId",
+"1".id "1.id", "1".name "1.name",
+"2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
+from "article" "0"
+left join "user" "1" on "1".id = "0".created_by_user_id
+left join "user_address" "2" on "2".user_id = "1".id
+where "0".date_deleted is null
+limit 1`)
+
+      // The "recipes" node
+      const result2 = fn(queryNodeList[1], [1, 2, 3])
+
+      expect(result2).toBe(`select
+"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title",
+"4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
+from "user" "_1"
+join lateral (
+select
+"id", "created_by_user_id", "image_id", "title"
+from  "recipe" "3"
+where "3"."created_by_user_id" = "_1"."id"
+and "3".image_id is not null
+limit 2 offset 0
+) as "3" on "3"."created_by_user_id" = "_1"."id"
+left join "image" "4" on "4".id = "3".image_id
+where "_1"."id" = any (values (1),(2),(3))`)
+
+      // The "userGroups" node
+      const result3 = fn(queryNodeList[2], [1, 2, 3])
+
+      expect(result3).toBe(`select
+"5".id "5.id", "5".name "5.name",
+"5"."user_to_user_group.user_id" "user_to_user_group.user_id", "5"."user_to_user_group.user_group_id" "user_to_user_group.user_group_id"
+from "user" "_1"
+join lateral (
+select
+"5"."id" "id", "5"."name" "name",
+"user_to_user_group".user_id "user_to_user_group.user_id", "user_to_user_group".user_group_id "user_to_user_group.user_group_id"
+from user_to_user_group "user_to_user_group"
+join "user_group" "5" on "5".id = "user_to_user_group"."user_group_id"
+where "user_to_user_group"."user_id" = "_1"."id"
+limit 5 offset 0
+) as "5" on "5"."user_to_user_group.user_id" = "_1"."id"
+where "_1"."id" = any (values (1),(2),(3))`)
+    })
+  })
+})

--- a/src/store/get/queryPlan.spec.ts
+++ b/src/store/get/queryPlan.spec.ts
@@ -106,16 +106,20 @@ describe('queryPlan', () => {
       expect(db.receivedQueries[0]).toEqual({
         parameters: undefined,
         sql: `select
-"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished", "0".created_by_user_id "0.createdByUserId", "1".id "1.id", "1".name "1.name", "2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
+"0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished", "0".created_by_user_id "0.createdByUserId",
+"1".id "1.id", "1".name "1.name",
+"2".user_id "2.userId", "2".street_address "2.streetAddress", "2".post_code "2.postCode"
 from "article" "0"
 left join "user" "1" on "1".id = "0".created_by_user_id
 left join "user_address" "2" on "2".user_id = "1".id
-where "0".date_deleted is null limit 1`,
+where "0".date_deleted is null
+limit 1`,
       })
       expect(db.receivedQueries[1]).toEqual({
         parameters: undefined,
         sql: `select
-"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title", "4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
+"3".id "3.id", "3".created_by_user_id "3.createdByUserId", "3".image_id "3.imageId", "3".title "3.title",
+"4".id "4.id", "4".file_name "4.fileName", "4".created_by_user_id "4.createdByUserId"
 from "recipe" "3"
 left join "image" "4" on "4".id = "3".image_id
 where "3".created_by_user_id = any (values (1),(2),(3))`,
@@ -175,7 +179,8 @@ limit 1`,
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-where "0".date_deleted is null limit 1`,
+where "0".date_deleted is null
+limit 1`,
       })
       expect(result).toBeNull()
     })
@@ -207,8 +212,7 @@ where "0".date_deleted is null limit 1`,
         parameters: undefined,
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
-from "article" "0"
-`,
+from "article" "0"`,
       })
       expect(result).toEqual([
         {
@@ -237,7 +241,8 @@ from "article" "0"
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-where "0".date_deleted is null limit 50 offset 50`,
+where "0".date_deleted is null
+limit 50 offset 50`,
       })
       expect(result).toEqual([])
     })
@@ -282,10 +287,12 @@ where "0".date_deleted is null limit 50 offset 50`,
       expect(db.receivedQueries[0]).toEqual({
         parameters: undefined,
         sql: `select
-"0".created_by_user_id "0.createdByUserId", "1".name "1.name", "1".id "1.id"
+"0".created_by_user_id "0.createdByUserId",
+"1".name "1.name", "1".id "1.id"
 from "article" "0"
 left join "user" "1" on "1".id = "0".created_by_user_id
-where ("0".date_deleted is null and "0".uuid = '123') limit 1`,
+where ("0".date_deleted is null and "0".uuid = '123')
+limit 1`,
       })
       expect(result).toEqual({
         user: {
@@ -351,10 +358,11 @@ limit 1`,
       expect(db.receivedQueries[1]).toEqual({
         parameters: undefined,
         sql: `select
-"1".id "1.id", "1".name "1.name", "user_to_user_group".user_id "user_to_user_group.user_id", "user_to_user_group".user_group_id "user_to_user_group.user_group_id"
+"1".id "1.id", "1".name "1.name",
+"user_to_user_group".user_id "user_to_user_group.user_id", "user_to_user_group".user_group_id "user_to_user_group.user_group_id"
 from user_to_user_group "user_to_user_group"
-join "user_group" "1" on "1".id = "user_to_user_group".user_group_id
-where "user_to_user_group".user_id = 1`,
+join "user_group" "1" on "1".id = "user_to_user_group"."user_group_id"
+where "user_to_user_group"."user_id" = 1`,
       })
       expect(result).toEqual({
         name: 'User 1',

--- a/src/store/get/queryPlan.spec.ts
+++ b/src/store/get/queryPlan.spec.ts
@@ -152,7 +152,6 @@ where "3".created_by_user_id = any (values (1),(2),(3))`,
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-
 limit 1`,
       })
       expect(result).toEqual({
@@ -176,7 +175,6 @@ limit 1`,
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-
 where "0".date_deleted is null limit 1`,
       })
       expect(result).toBeNull()
@@ -210,7 +208,6 @@ where "0".date_deleted is null limit 1`,
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-
 `,
       })
       expect(result).toEqual([
@@ -240,7 +237,6 @@ from "article" "0"
         sql: `select
 "0".uuid "0.uuid", "0".title "0.title", "0".date_created "0.dateCreated", "0".date_published "0.datePublished"
 from "article" "0"
-
 where "0".date_deleted is null limit 50 offset 50`,
       })
       expect(result).toEqual([])
@@ -350,7 +346,6 @@ where ("0".date_deleted is null and "0".uuid = '123') limit 1`,
         sql: `select
 "0".name "0.name", "0".id "0.id"
 from "user" "0"
-
 limit 1`,
       })
       expect(db.receivedQueries[1]).toEqual({
@@ -359,7 +354,6 @@ limit 1`,
 "1".id "1.id", "1".name "1.name", "user_to_user_group".user_id "user_to_user_group.user_id", "user_to_user_group".user_group_id "user_to_user_group.user_group_id"
 from user_to_user_group "user_to_user_group"
 join "user_group" "1" on "1".id = "user_to_user_group".user_group_id
-
 where "user_to_user_group".user_id = 1`,
       })
       expect(result).toEqual({

--- a/src/store/get/types.ts
+++ b/src/store/get/types.ts
@@ -89,7 +89,7 @@ export type FieldsInfo = {
    */
   fieldToFullyQualifiedColumnName: { [fieldName: string]: string }
   /**
-   * Join table info
+   * Unquoted join table name
    */
   joinTableAlias?: string
   joinTableParentColumnNameAlias?: string
@@ -134,10 +134,18 @@ export type DataNode<
    */
   tableAlias: string
   /**
-   * Creates a list of the column sql segments, e.g. `"0".id`, `"0".name`, ` "0".email`
+   * Unquoted alias for the table of this data node, i.e. `0`.
+   */
+  unquotedTableAlias: string
+  /**
+   * Creates a list of the column sql segments, e.g. `"0".id "0.id"`, `"0".name "0.name"`, ` "0".email "0.email"`
    */
   createColumnsSqlSegments: () => string[]
 }
+
+export type PluralDataNode = DataNode<true>
+
+export type NonPluralDataNode = DataNode<false>
 
 export type DataNodes = { [dataNodeId: number]: DataNode }
 
@@ -182,11 +190,6 @@ export type QueryNodeSql<
    */
   modifyRootDataNodeDataFilter: (newDataFilter: DataFilterNodeOrGroup) => void
 })
-
-export enum QueryNodeToSqlStrategy {
-  SINGLE_QUERY,
-  MULTIPLE_QUERY_WITH_UNION_ALL
-}
 
 /**
  * A Query Node represents a single SQL query that is ran. Query nodes are composed of

--- a/src/store/get/types.ts
+++ b/src/store/get/types.ts
@@ -8,28 +8,73 @@ import { AnyGetFunctionOptions, GetFunctionOptions, GetFunctionResult } from '..
 export type RelatedDataInfo<
   TIsPlural extends boolean = boolean,
 > = {
+  /**
+   * The name of the property name within the original get function options that
+   * birthed this Data Node.
+   */
   relatedDataPropName: string
+  /**
+   * The field ref of the parent Data Node's side of the relation.
+   */
   parentFieldRef: FieldRef
+  /**
+   * The field ref of this Data Node's side of the relation.
+   */
   fieldRef: FieldRef
+  /**
+   * Denotes the Data Node as either singular or plural. This essentially represents if
+   * this Data Node is the "to-many" side of `relation`.
+   */
   isPlural: TIsPlural
+  /**
+   * The relation between this Data Node and it's parent Data Node.
+   */
   relation: Relation
 }
 
 export type RelatedDataInfoDict = { [relatedDataPropName: string]: RelatedDataInfo }
 
 export type UnresolvedDataNode = RelatedDataInfo & {
+  /**
+   * Unique identifier of the Data Node.
+   */
   id: number
+  /**
+   * The Data Format of the Data Node. This is driven by what the parent Data Node
+   * is, and what related data property name links them.
+   */
   dataFormat: DataFormat
+  /**
+   * Identifier of the parent Data Node.
+   */
   parentId: number
+  /**
+   * List of identifiers of the child Data Nodes.
+   */
   childIds: number[]
+  /**
+   * The original get function options for this Data Node.
+   */
   options: AnyGetFunctionOptions
 }
 
 export type UnresolvedDataNodes = { [dataNodeId: number]: UnresolvedDataNode }
 
 export type FieldsInfo = {
+  /**
+   * List of field names that must be included in the select query of the Query Node
+   * of the Data Node.
+   */
   fieldsToSelectFor: string[]
+  /**
+   * List of field names that have been included in `fieldsToSelectFor` only because they
+   * are required by relations.
+   */
   fieldsOnlyUsedForRelations: string[]
+  /**
+   * List of field names within `fieldsToSelectFor` that must be kept in the final record(s)
+   * of this Data Node.
+   */
   fieldsToKeepInRecord: string[]
   /**
    * E.g. `user_id` => `0.userId`
@@ -52,19 +97,45 @@ export type FieldsInfo = {
   joinTableFullyQualifiedColumnName?: string
 }
 
+/**
+ * A Data Node represents a single table as part of a Query Node's SQL.
+ */
 export type DataNode<
   TIsPlural extends boolean = boolean
 > = RelatedDataInfo<TIsPlural> & {
+  /**
+   * Unique identifier of the Data Node.
+   */
   id: number
+  /**
+   * The Data Format of the Data Node. This is driven by what the parent Data Node
+   * is, and what related data property name links them.
+   */
   dataFormat: DataFormat
+  /**
+   * Reference to the parent Data Node.
+   */
   parent: DataNode
+  /**
+   * References to the child Data Nodes.
+   */
   children: DataNodes
+  /**
+   * The original get function options for this Data Node.
+   */
   options: AnyGetFunctionOptions<TIsPlural>
+  /**
+   * A collection of useful information about the fields, i.e. fields to include in
+   * the select query for this Data Node, column name aliases, etc.
+   */
   fieldsInfo: FieldsInfo
   /**
    * Quoted alias for the table of this data node, i.e. `"0"`.
    */
   tableAlias: string
+  /**
+   * Creates a list of the column sql segments, e.g. `"0".id`, `"0".name`, ` "0".email`
+   */
   createColumnsSqlSegments: () => string[]
 }
 
@@ -86,32 +157,89 @@ export type ChildQueryNodeLink = {
   sourceDataNode: DataNode
 }
 
+/**
+ * SQL representation of a Query Node.
+ */
 export type QueryNodeSql<
   TIsPlural extends boolean = boolean
 > = {
+  /**
+   * SQL query text
+   */
   sql: string
+  /**
+   * Updates the linked field values-dependant part of the SQL query text.
+   */
   updateLinkedFieldValues: (values: any[]) => void
 } & (TIsPlural extends true ? {
+  /**
+   * Modifies the part of the SQL query text that is dependant on the root Data Node data query.
+   */
   modifyRootDataNodeDataQuery: (newDataQuery: DataQueryRecord) => void
 } : {
+  /**
+   * Modifies the part of the SQL query text that is dependant on the root Data Node data filter.
+   */
   modifyRootDataNodeDataFilter: (newDataFilter: DataFilterNodeOrGroup) => void
 })
 
+/**
+ * A Query Node represents a single SQL query that is ran. Query nodes are composed of
+ * a directed acyclical graph of Data Nodes, with one of them as a root Data Node and
+ * all others non-root.
+ *
+ * The root Data Node is either singular or plural, but all other Data Nodes (non-root)
+ * are always singular.
+ *
+ * The root Data Node represents the "root SQL query", i.e. `SELECT ... FROM {root data node table}`.
+ * Non-root data nodes, being singular, are LEFT JOIN-ed onto the root SQL query.
+ */
 export type QueryNode<
   TIsPlural extends boolean = boolean
 > = {
+  /**
+   * Unique identifier of the Query Node.
+   */
   id: number
+  /**
+   * Display name of the Query Node. This has no effect on the actual execution of the Query Node.
+   */
   name: string
+  /**
+   * The root Data Node.
+   */
   rootDataNode: DataNode<TIsPlural>
+  /**
+   * Non-root Data Nodes.
+   */
   nonRootDataNodes: NonRootDataNodes
+  /**
+   * All Data Nodes, root and non-root.
+   */
   dataNodes: DataNodes
+  /**
+   * A reference to the parent Query Node of this Query Node.
+   */
   parentQueryNodeLink: ParentQueryNodeLink
+  /**
+   * A list of references to the child Query Nodes of this Query Node.
+   */
   childQueryNodeLinks: ChildQueryNodeLink[]
+  /**
+   * Cnnverts this Query Node to QueryNodeSql.
+   */
   toSql: (linkedFieldValues?: any[]) => QueryNodeSql
 }
 
 export type QueryNodes = { [queryNodeId: number]: QueryNode }
 
+/**
+ * A Query Plan represents a directed acyclical graph of Query Nodes, with one root Query Node
+ * and all others non-root Query Nodes.
+ *
+ * Query Plans are created from get function options, and can be re-executed with different root
+ * Data Node data queries/filters for more efficient performance.
+ */
 export type QueryPlan<
   T extends DataFormatDeclarations = DataFormatDeclarations,
   K extends RelationDeclarations<T> = RelationDeclarations<T>,
@@ -124,6 +252,8 @@ export type QueryPlan<
   rootQueryNode: QueryNode
   /**
    * Executes the query plan, using the given database service `db`, returning the results.
+   *
+   * This will recursively work through the Query Node graph, starting at the root Query Node.
    */
   execute: (db: SimplePgClient) => Promise<GetFunctionResult<T, K, L, TIsPlural, TOptions>>
 } & (TIsPlural extends true ? {

--- a/src/store/get/types.ts
+++ b/src/store/get/types.ts
@@ -183,6 +183,11 @@ export type QueryNodeSql<
   modifyRootDataNodeDataFilter: (newDataFilter: DataFilterNodeOrGroup) => void
 })
 
+export enum QueryNodeToSqlStrategy {
+  SINGLE_QUERY,
+  MULTIPLE_QUERY_WITH_UNION_ALL
+}
+
 /**
  * A Query Node represents a single SQL query that is ran. Query nodes are composed of
  * a directed acyclical graph of Data Nodes, with one of them as a root Data Node and


### PR DESCRIPTION
The goal of this PR is to fill in a functional gap with the getSingle and getMultiple calls.

When a plural-to-plural Query Node link occurs, a list of linked foreign rows must be retrieved for each row in a list of local rows. When the get function options node for the foreign rows has a Data Query with some form of row range constraint (i.e. pageSize or pageSize and page number), then the root data node data query SQL operates over all of the linked foreign rows in aggregate, rather than the linked foreign rows *per local linked value*.

For example, assume that we have a very simple ts-pg-orm instance with two Data Formats and one Relation: Article <<-->> Comment. Then, assume we want to make the following getMultiple call:

```typescript
stores.article.getMultiple({
  relations: {
    comment: {
      query: { pageSize: 5, sorting: [{ field: 'dateCreated', dir: SortingDirection.DESC }] }
    }
  }
})
```

These options are saying *"get me a list of articles, each with their 5 latest comments"*.

Currently, in master, how the Query Plan framework works is it will convert the `comment: { ... }` options node into a Query Node, and apply the `query` for the linked comments for *all* articles in aggregate, meaning that even though we would expect each article to have their 5 latest comments, and likely have approximately `{N_Articles} * 5` comment rows, we would actually only get 5 comment rows *in total* for all of the articles.

This PR approaches the problem by using a JOIN LATERAL when there is some row range constraint for a plural-to-plural Query Node link.

This PR sacrifices some of the partial SQL recreation performance optimization for when re-executing a query plan, since all query nodes SQL is now fully recreated for each execution. This is to simplify the change of this PR. A future PR will be done to reimplement the partial SQL recreation performance optimization for the new SQL creation logic (i.e. related data paing logic).