### PR TITLE
Bug - Related data folding fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pg-orm",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Typescript PostgreSQL ORM",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/common/obj.spec.ts
+++ b/src/common/obj.spec.ts
@@ -1,0 +1,57 @@
+import { setObjPropDeep } from './obj'
+
+describe('setObjPropDeep', () => {
+  const fn = setObjPropDeep
+
+  test('basic test', () => {
+    const obj = {
+      a: {
+        b: {
+          c: {
+
+          },
+        },
+      },
+    }
+
+    const newObj = fn(obj, ['a', 'b', 'c', 'd'], 'new value')
+
+    expect(newObj).toEqual({
+      a: {
+        b: {
+          c: {
+            d: 'new value',
+          },
+        },
+      },
+    })
+  })
+
+  test('basic test - createIfNotExists = true', () => {
+    const obj = {
+      a: { },
+    }
+
+    const newObj = fn(obj, ['a', 'b', 'c', 'd'], 'new value', true)
+
+    expect(newObj).toEqual({
+      a: {
+        b: {
+          c: {
+            d: 'new value',
+          },
+        },
+      },
+    })
+  })
+
+  test('basic test - single path segment', () => {
+    const obj = {}
+
+    const newObj = fn(obj, ['a'], 'new value', false)
+
+    expect(newObj).toEqual({
+      a: 'new value',
+    })
+  })
+})

--- a/src/common/obj.ts
+++ b/src/common/obj.ts
@@ -1,0 +1,31 @@
+export const setObjPropDeep = (obj: any, propPath: string[], value: any, createIfNotExists: boolean = false) => {
+  let currentObj = obj
+  for (let i = 0; i < propPath.length; i += 1) {
+    if (i === propPath.length - 1) {
+      currentObj[propPath[i]] = value
+      return obj
+    }
+
+    if (currentObj[propPath[i]] == null && createIfNotExists)
+      currentObj[propPath[i]] = {}
+
+    currentObj = currentObj[propPath[i]]
+  }
+
+  return obj
+}
+
+export const readObjPropDeep = (obj: any, propPath: string[]) => {
+  let currentObj = obj
+  for (let i = 0; i < propPath.length; i += 1) {
+    if (i === propPath.length - 1)
+      return currentObj[propPath[i]]
+
+    if (currentObj[propPath[i]] == null)
+      return undefined
+
+    currentObj = currentObj[propPath[i]]
+  }
+
+  return obj
+}

--- a/src/integrationTests/common.ts
+++ b/src/integrationTests/common.ts
@@ -45,9 +45,9 @@ export const deleteAllSampleData = async (stores: Stores) => {
 }
 
 const executeTest = async (stores: Stores, tests: Test[], onComplete: () => void, i: number = 0) => {
+  await deleteAllSampleData(stores)
   await addSampleData(stores)
   await tests[i](stores)
-  await deleteAllSampleData(stores)
   if (i < tests.length - 1)
     await executeTest(stores, tests, onComplete, i + 1)
   else

--- a/src/integrationTests/orm.ts
+++ b/src/integrationTests/orm.ts
@@ -117,7 +117,7 @@ export const provisionOrm = async (): Promise<Stores> => {
     extensions: ['uuid-ossp'],
     events: {
       ...createConsoleLogEventHandlers(),
-      // TODO: This can cause a lot of console noise if enabled
+      // This can cause a lot of console noise if enabled
       // onQuery: (q, m, sql, p) => console.log(m, p),
       onQueryError: (q, m, sql, p) => console.log(m),
     },

--- a/src/integrationTests/tests/get/deepRelatedata.ts
+++ b/src/integrationTests/tests/get/deepRelatedata.ts
@@ -1,0 +1,68 @@
+import { DataFilterLogic, Operator } from '@samhuk/data-filter/dist/types'
+import { test } from '../../common'
+
+export const deepRelatedDataTest = test('deep related data', async (stores, assert) => {
+  const result = await stores.user.get({
+    fields: ['name', 'email'],
+    filter: {
+      logic: DataFilterLogic.AND,
+      nodes: [
+        { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+        { field: 'name', op: Operator.EQUALS, val: 'User 1' },
+      ],
+    },
+    relations: {
+      userAddress: {
+        fields: ['city', 'country', 'postCode', 'streetAddress'],
+        query: {
+          filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+        },
+        relations: {
+          user: {
+            fields: ['email', 'name'],
+            query: {
+              filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+            },
+            relations: {
+              articles: {
+                fields: ['title'],
+                query: {
+                  filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+                },
+              },
+              userGroups: {
+                fields: ['name'],
+                query: {
+                  filter: { field: 'dateDeleted', op: Operator.EQUALS, val: null },
+                  pageSize: 2,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  assert(result, {
+    name: 'User 1',
+    email: 'user1@email.com',
+    userAddress: {
+      city: 'London',
+      country: 'UK',
+      postCode: 'SE11 119',
+      streetAddress: '1 FooStreet Lane',
+      user: {
+        email: 'user1@email.com',
+        name: 'User 1',
+        articles: [
+          { title: 'I am User 1' },
+        ],
+        userGroups: [
+          { name: 'User Group 1' },
+          { name: 'User Group 2' },
+        ],
+      },
+    },
+  })
+})

--- a/src/integrationTests/tests/get/index.ts
+++ b/src/integrationTests/tests/get/index.ts
@@ -1,7 +1,11 @@
 import { testGroup } from '../../common'
 import { basicTest } from './basic'
+import { deepRelatedDataTest } from './deepRelatedata'
+import { relatedDataPagingTest } from './relatedDataPaging'
 
 export const getTests = testGroup(
   'get',
   basicTest,
+  relatedDataPagingTest,
+  deepRelatedDataTest,
 )

--- a/src/integrationTests/tests/get/relatedDataPaging.ts
+++ b/src/integrationTests/tests/get/relatedDataPaging.ts
@@ -1,0 +1,61 @@
+import { Operator } from '@samhuk/data-filter/dist/types'
+import { SortingDirection } from '@samhuk/data-query/dist/sorting/types'
+import { test } from '../../common'
+
+export const relatedDataPagingTest = test('related data paging', async (stores, assert) => {
+  const result = await stores.user.getMany({
+    fields: ['name', 'email'],
+    query: {
+      filter: {
+        field: 'dateDeleted', op: Operator.EQUALS, val: null,
+      },
+    },
+    relations: {
+      userGroups: {
+        fields: ['name', 'description'],
+        query: {
+          page: 1,
+          pageSize: 2,
+          sorting: [{ field: 'dateCreated', dir: SortingDirection.DESC }],
+        },
+      },
+    },
+  })
+
+  assert(result, [
+    {
+      email: 'user1@email.com',
+      name: 'User 1',
+      userGroups: [
+        {
+          description: null,
+          name: 'User Group 2',
+        },
+        {
+          description: null,
+          name: 'User Group 3',
+        },
+      ],
+    },
+    {
+      email: 'user2@email.com',
+      name: 'User 2',
+      userGroups: [
+        {
+          description: null,
+          name: 'User Group 2',
+        },
+      ],
+    },
+    {
+      email: 'user3@email.com',
+      name: 'User 3',
+      userGroups: [
+        {
+          description: null,
+          name: 'User Group 3',
+        },
+      ],
+    },
+  ])
+})

--- a/src/store/index.spec.ts
+++ b/src/store/index.spec.ts
@@ -25,30 +25,6 @@ describe('store', () => {
               '2.streetAddress': '1 Foo Road',
               '2.postCode': 'SE1 9U7',
             },
-            {
-              '0.uuid': '456',
-              '0.title': 'Article 2 by User 2',
-              '0.dateCreated': '1970-01-01',
-              '0.datePublished': '1970-01-01',
-              '0.createdByUserId': 2,
-              '1.id': 2,
-              '1.name': 'User 2',
-              '2.userId': 2,
-              '2.streetAddress': '2 Foo Road',
-              '2.postCode': 'SE1 9U7',
-            },
-            {
-              '0.uuid': '789',
-              '0.title': 'Article 3 by User 3',
-              '0.dateCreated': '1970-01-01',
-              '0.datePublished': '1970-01-01',
-              '0.createdByUserId': 3,
-              '1.id': 3,
-              '1.name': 'User 3',
-              '2.userId': 3,
-              '2.streetAddress': '3 Foo Road',
-              '2.postCode': 'SE1 9U7',
-            },
           ],
           [],
         ])
@@ -75,7 +51,6 @@ describe('store', () => {
         expect(result).toEqual({
           dateCreated: '1970-01-01',
           datePublished: '1970-01-01',
-          recipes: [],
           title: 'Article 1 by User 1',
           user: {
             name: 'User 1',
@@ -84,6 +59,7 @@ describe('store', () => {
               streetAddress: '1 Foo Road',
               userId: 1,
             },
+            recipes: [],
           },
           uuid: '123',
         })


### PR DESCRIPTION
This PR adds more integration tests that found some irregularities with how related data is folded up in the Query Plan framework.

The full story is extremely long, however it is centered around the foldResults() function within queryPlan.ts.

Unit tests have been amended and some initial integration tests added to cover this.

Future PR will be done to run the integration tests as a github action, but need to research how to setup a postgresql server.